### PR TITLE
server: avoid sending unwanted withdrawals to iBGP peers

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -367,7 +367,7 @@ func filterpath(peer *Peer, path, old *table.Path) *table.Path {
 		}
 
 		if ignore {
-			if !path.IsWithdraw && old != nil && old.GetSource().Address.String() != peer.ID() {
+			if !path.IsWithdraw && old != nil && old.GetSource().Address.String() != peer.ID() && old.GetSource().AS != peer.fsm.pConf.State.PeerAs {
 				// we advertise a route from ebgp,
 				// which is the old best. We got the
 				// new best from ibgp. We don't


### PR DESCRIPTION
when the old best was from iBGP, we don't need to send withdrawals
to iBGP peers.

Signed-off-by: Wataru Ishida <ishida.wataru@lab.ntt.co.jp>